### PR TITLE
removing explicit docker pinning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "cloudformation-cli>=0.1.14",
-        "docker>=3.7,<5",
         "zipfile38>=0.0.3,<0.2",
     ],
     entry_points={


### PR DESCRIPTION
introduced in https://github.com/aws-cloudformation/cloudformation-cli-typescript-plugin/pull/43, but `docker` is already an indirect dependency from `cloudformation-cli`, so this was just pinning `docker` version stricter than `cloudformation-cli`, which causes issues
https://github.com/aws-cloudformation/cloudformation-cli/issues/727