### PR TITLE
Add type configuration support to the typescript cli plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ tests/**/*.d.ts
 # Node.js
 node_modules/
 coverage/
+
+*.iml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,8 @@ repos:
   - repo: https://github.com/ambv/black
     rev: stable
     hooks:
-    - id: black
-      # language_version: python3.6
+      - id: black
+        # language_version: python3.6
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ If you are using this package to build resource providers for CloudFormation, in
 
 **Prerequisites**
 
- - Python version 3.6 or above
- - [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
- - Your choice of TypeScript IDE
+- Python version 3.6 or above
+- [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
+- Your choice of TypeScript IDE
 
 **Installation**
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ pip3 install \
 
 That ensures neither is accidentally installed from PyPI.
 
+For changes to the typescript library "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib" pack up the compiled javascript:
+
+```shell
+npm run build
+npm pack
+```
+
+You can then install this in a cfn resource project using:
+
+```shell
+npm install ../path/to/cloudformation-cli-typescript-plugin/amazon-web-services-cloudformation-cloudformation-cli-typescript-lib-1.0.1.tgz
+```
+
 Linting and running unit tests is done via [pre-commit](https://pre-commit.com/), and so is performed automatically on commit after being installed (`pre-commit install`). The continuous integration also runs these checks. Manual options are available so you don't have to commit:
 
 ```shell

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -161,6 +161,15 @@ class TypescriptLanguagePlugin(LanguagePlugin):
 
         models = resolve_models(project.schema)
 
+        if project.configuration_schema:
+            configuration_models = resolve_models(
+                project.configuration_schema, "TypeConfigurationModel"
+            )
+        else:
+            configuration_models = {"TypeConfigurationModel": {}}
+
+        models.update(configuration_models)
+
         path = self.package_root / "models.ts"
         LOG.debug("Writing file: %s", path)
         template = self.env.get_template("models.ts")
@@ -168,6 +177,7 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             lib_name=SUPPORT_LIB_NAME,
             type_name=project.type_name,
             models=models,
+            contains_type_configuration=project.configuration_schema,
             primaryIdentifier=project.schema.get("primaryIdentifier", []),
             additionalIdentifiers=project.schema.get("additionalIdentifiers", []),
         )

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -173,6 +173,7 @@ class TypescriptLanguagePlugin(LanguagePlugin):
         path = self.package_root / "models.ts"
         LOG.debug("Writing file: %s", path)
         template = self.env.get_template("models.ts")
+
         contents = template.render(
             lib_name=SUPPORT_LIB_NAME,
             type_name=project.type_name,
@@ -186,6 +187,8 @@ class TypescriptLanguagePlugin(LanguagePlugin):
         LOG.debug("Generate complete")
 
     def _pre_package(self, build_path):
+        # Caller should own/delete this, not us.
+        # pylint: disable=consider-using-with
         f = TemporaryFile("w+b")
 
         # pylint: disable=unexpected-keyword-arg

--- a/python/rpdk/typescript/templates/handlers.ts
+++ b/python/rpdk/typescript/templates/handlers.ts
@@ -11,7 +11,7 @@ import {
     ResourceHandlerRequest,
     SessionProxy,
 } from '{{lib_name}}';
-import { ResourceModel } from './models';
+import { ResourceModel, TypeConfigurationModel } from './models';
 
 interface CallbackContext extends Record<string, any> {}
 
@@ -154,7 +154,7 @@ class Resource extends BaseResource<ResourceModel> {
     }
 }
 
-export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel);
+export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel, TypeConfigurationModel);
 
 // Entrypoint for production usage after registered in CloudFormation
 export const entrypoint = resource.entrypoint;

--- a/python/rpdk/typescript/templates/handlers.ts
+++ b/python/rpdk/typescript/templates/handlers.ts
@@ -32,6 +32,7 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        typeConfiguration: TypeConfigurationModel,
         logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
@@ -70,6 +71,7 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        typeConfiguration: TypeConfigurationModel,
         logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
@@ -95,6 +97,7 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        typeConfiguration: TypeConfigurationModel,
         logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
@@ -119,6 +122,7 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        typeConfiguration: TypeConfigurationModel,
         logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
@@ -142,6 +146,7 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        typeConfiguration: TypeConfigurationModel,
         logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);

--- a/python/rpdk/typescript/templates/handlers.ts
+++ b/python/rpdk/typescript/templates/handlers.ts
@@ -25,6 +25,8 @@ class Resource extends BaseResource<ResourceModel> {
      * @param request The request object for the provisioning request passed to the implementor
      * @param callbackContext Custom context object to allow the passing through of additional
      * state or metadata between subsequent retries
+     * @param typeConfiguration Configuration data for this resource type, in the given account
+     * and region
      * @param logger Logger to proxy requests to default publishers
      */
     @handlerEvent(Action.Create)
@@ -64,6 +66,8 @@ class Resource extends BaseResource<ResourceModel> {
      * @param request The request object for the provisioning request passed to the implementor
      * @param callbackContext Custom context object to allow the passing through of additional
      * state or metadata between subsequent retries
+     * @param typeConfiguration Configuration data for this resource type, in the given account
+     * and region
      * @param logger Logger to proxy requests to default publishers
      */
     @handlerEvent(Action.Update)
@@ -90,6 +94,8 @@ class Resource extends BaseResource<ResourceModel> {
      * @param request The request object for the provisioning request passed to the implementor
      * @param callbackContext Custom context object to allow the passing through of additional
      * state or metadata between subsequent retries
+     * @param typeConfiguration Configuration data for this resource type, in the given account
+     * and region
      * @param logger Logger to proxy requests to default publishers
      */
     @handlerEvent(Action.Delete)
@@ -115,6 +121,8 @@ class Resource extends BaseResource<ResourceModel> {
      * @param request The request object for the provisioning request passed to the implementor
      * @param callbackContext Custom context object to allow the passing through of additional
      * state or metadata between subsequent retries
+     * @param typeConfiguration Configuration data for this resource type, in the given account
+     * and region
      * @param logger Logger to proxy requests to default publishers
      */
     @handlerEvent(Action.Read)
@@ -139,6 +147,8 @@ class Resource extends BaseResource<ResourceModel> {
      * @param request The request object for the provisioning request passed to the implementor
      * @param callbackContext Custom context object to allow the passing through of additional
      * state or metadata between subsequent retries
+     * @param typeConfiguration Configuration data for this resource type, in the given account
+     * and region
      * @param logger Logger to proxy requests to default publishers
      */
     @handlerEvent(Action.List)

--- a/python/rpdk/typescript/templates/handlers.ts
+++ b/python/rpdk/typescript/templates/handlers.ts
@@ -34,8 +34,8 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        logger: LoggerProxy,
         typeConfiguration: TypeConfigurationModel,
-        logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
         const progress = ProgressEvent.progress<ProgressEvent<ResourceModel, CallbackContext>>(model);
@@ -75,8 +75,8 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        logger: LoggerProxy,
         typeConfiguration: TypeConfigurationModel,
-        logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
         const progress = ProgressEvent.progress<ProgressEvent<ResourceModel, CallbackContext>>(model);
@@ -103,8 +103,8 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        logger: LoggerProxy,
         typeConfiguration: TypeConfigurationModel,
-        logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
         const progress = ProgressEvent.progress<ProgressEvent<ResourceModel, CallbackContext>>();
@@ -130,8 +130,8 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        logger: LoggerProxy,
         typeConfiguration: TypeConfigurationModel,
-        logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
         // TODO: put code here
@@ -156,8 +156,8 @@ class Resource extends BaseResource<ResourceModel> {
         session: Optional<SessionProxy>,
         request: ResourceHandlerRequest<ResourceModel>,
         callbackContext: CallbackContext,
+        logger: LoggerProxy,
         typeConfiguration: TypeConfigurationModel,
-        logger: LoggerProxy
     ): Promise<ProgressEvent<ResourceModel, CallbackContext>> {
         const model = new ResourceModel(request.desiredResourceState);
         // TODO: put code here
@@ -169,7 +169,8 @@ class Resource extends BaseResource<ResourceModel> {
     }
 }
 
-export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel, TypeConfigurationModel);
+// @ts-ignore // if running against v1.0.1 or earlier of plugin the 5th argument is not known but best to ignored (runtime code may warn)
+export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel, null, null, TypeConfigurationModel)!;
 
 // Entrypoint for production usage after registered in CloudFormation
 export const entrypoint = resource.entrypoint;

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -22,6 +22,15 @@ export class NotUpdatable extends BaseHandlerException {}
 
 export class InvalidRequest extends BaseHandlerException {}
 
+export class InvalidTypeConfiguration extends BaseHandlerException {
+    constructor(typeName: string, reason: string) {
+        super(
+            `Invalid TypeConfiguration provided for type '${typeName}'. Reason: ${reason}`,
+            HandlerErrorCode.InvalidTypeConfiguration
+        );
+    }
+}
+
 export class AccessDenied extends BaseHandlerException {}
 
 export class InvalidCredentials extends BaseHandlerException {}

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -160,6 +160,7 @@ export enum HandlerErrorCode {
     ServiceInternalError = 'ServiceInternalError',
     NetworkFailure = 'NetworkFailure',
     InternalFailure = 'InternalFailure',
+    InvalidTypeConfiguration = 'InvalidTypeConfiguration',
 }
 
 export interface Credentials {
@@ -261,6 +262,7 @@ export class RequestData<T = Dict> extends BaseDto {
     @Expose() providerCredentials?: Credentials;
     @Expose() previousResourceProperties?: T;
     @Expose() previousStackTags?: Dict<string>;
+    @Expose() typeConfiguration?: Dict<string>;
 }
 
 export class HandlerRequest<ResourceT = Dict, CallbackT = Dict> extends BaseDto {

--- a/tests/lib/resource.test.ts
+++ b/tests/lib/resource.test.ts
@@ -139,9 +139,9 @@ describe('when getting resource', () => {
         const instance = new Resource(
             TYPE_NAME,
             MockModel,
-            MockTypeConfigurationModel,
             workerPool,
-            handlers
+            handlers,
+            MockTypeConfigurationModel
         );
         return instance;
     };
@@ -165,7 +165,13 @@ describe('when getting resource', () => {
 
     test('entrypoint success production-like', async () => {
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const event = await resource.entrypoint(entrypointPayload, null);
         expect(spyInitializeRuntime).toBeCalledTimes(1);
@@ -178,7 +184,13 @@ describe('when getting resource', () => {
     });
 
     test('publish exception metric without proxy', async () => {
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, jest.fn());
         const mockPublishException = jest.fn();
         MetricsPublisherProxy.prototype[
@@ -193,7 +205,13 @@ describe('when getting resource', () => {
     });
 
     test('entrypoint handler raises', async () => {
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         const mockPublishException = jest.fn();
         MetricsPublisherProxy.prototype[
             'publishExceptionMetric'
@@ -217,7 +235,13 @@ describe('when getting resource', () => {
     });
 
     test('entrypoint non mutating action', async () => {
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         entrypointPayload['action'] = 'READ';
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
         resource.addHandler(Action.Create, mockHandler);
@@ -243,7 +267,13 @@ describe('when getting resource', () => {
         const mockPublishMessage = jest.fn().mockResolvedValue({});
         LambdaLogPublisher.prototype['publishMessage'] = mockPublishMessage;
         CloudWatchLogPublisher.prototype['publishMessage'] = mockPublishMessage;
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         entrypointPayload['action'] = 'READ';
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
         resource.addHandler(Action.Read, mockHandler);
@@ -272,7 +302,13 @@ describe('when getting resource', () => {
         entrypointPayload['callbackContext'] = { a: 'b' };
         const event = ProgressEvent.success(null, { c: 'd' });
         const mockHandler: jest.Mock = jest.fn(() => event);
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const response = await resource.entrypoint(entrypointPayload, null);
         expect(response).toMatchObject({
@@ -285,8 +321,8 @@ describe('when getting resource', () => {
             expect.any(SessionProxy),
             expect.any(BaseResourceHandlerRequest),
             entrypointPayload['callbackContext'],
-            expect.any(MockTypeConfigurationModel),
-            expect.any(LoggerProxy)
+            expect.any(LoggerProxy),
+            expect.any(MockTypeConfigurationModel)
         );
     });
 
@@ -295,7 +331,13 @@ describe('when getting resource', () => {
         const event = ProgressEvent.progress(null, { c: 'd' });
         event.callbackDelaySeconds = 5;
         const mockHandler: jest.Mock = jest.fn(() => event);
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const response = await resource.entrypoint(entrypointPayload, null);
         expect(spyInitializeRuntime).toBeCalledTimes(1);
@@ -310,8 +352,8 @@ describe('when getting resource', () => {
             expect.any(SessionProxy),
             expect.any(BaseResourceHandlerRequest),
             {},
-            expect.any(MockTypeConfigurationModel),
-            expect.any(LoggerProxy)
+            expect.any(LoggerProxy),
+            expect.any(MockTypeConfigurationModel)
         );
     });
 
@@ -321,7 +363,13 @@ describe('when getting resource', () => {
         const event = ProgressEvent.progress(null, { c: 'd' });
         event.callbackDelaySeconds = 5;
         const mockHandler: jest.Mock = jest.fn(() => event);
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const response = await resource.entrypoint(entrypointPayload, null);
         expect(spyInitializeRuntime).toBeCalledTimes(1);
@@ -336,14 +384,20 @@ describe('when getting resource', () => {
             expect.any(SessionProxy),
             expect.any(BaseResourceHandlerRequest),
             entrypointPayload.callbackContext,
-            null,
-            expect.any(LoggerProxy)
+            expect.any(LoggerProxy),
+            null
         );
     });
 
     test('entrypoint success without caller provider creds', async () => {
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const expected = {
             message: '',
@@ -365,7 +419,13 @@ describe('when getting resource', () => {
 
     test('entrypoint with log stream failure', async () => {
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const spyPrepareLogStream = jest
             .spyOn<any, any>(CloudWatchLogHelper.prototype, 'prepareLogStream')
@@ -443,13 +503,22 @@ describe('when getting resource', () => {
         };
         expect(castResourceRequest).toThrow(exceptions.InvalidRequest);
         expect(castResourceRequest).toThrow(
-            "TypeError: Cannot read property 'resourceProperties' of null (TypeError)"
+            // previously tested for (1), but now seeing (2); error message probably depends on version of JS/TS
+            // (1) "TypeError: Cannot read property 'resourceProperties' of null (TypeError)"
+            // (2) "TypeError: Cannot read properties of null (reading 'resourceProperties') (TypeError)"
+            /TypeError: Cannot read propert.*'resourceProperties'.*/
         );
     });
 
     test('parse request valid request and cast resource request', () => {
         const spyDeserialize: jest.SpyInstance = jest.spyOn(MockModel, 'deserialize');
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
 
         const [
             [callerCredentials, providerCredentials],
@@ -503,7 +572,13 @@ describe('when getting resource', () => {
                     'Not allowed to submit a new task after progress tracker has been closed',
             });
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         const event = await resource.entrypoint(entrypointPayload, lambdaContext);
         expect(spyInitializeRuntime).toBeCalledTimes(1);
@@ -519,7 +594,13 @@ describe('when getting resource', () => {
     test('entrypoint success with two consecutive calls', async () => {
         // We are emulating the execution context reuse in the lambda function
         const mockHandler: jest.Mock = jest.fn(() => ProgressEvent.success());
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, mockHandler);
         jest.spyOn<any, any>(S3LogHelper.prototype, 'prepareFolder').mockResolvedValue(
             null
@@ -557,9 +638,9 @@ describe('when getting resource', () => {
         const resource = new ResourceEventHandler(
             null,
             null,
-            null,
             workerPool,
-            handlers
+            handlers,
+            null
         );
         expect(resource['handlers'].get(Action.Create)).toBe(resource.create);
         expect(resource['handlers'].get(Action.Read)).toBe(resource.read);
@@ -587,9 +668,9 @@ describe('when getting resource', () => {
         const resource = new ResourceEventHandler(
             TYPE_NAME,
             MockModel,
-            MockTypeConfigurationModel,
             workerPool,
-            handlers
+            handlers,
+            MockTypeConfigurationModel
         );
         const event = await resource.testEntrypoint(testEntrypointPayload, null);
         expect(event.status).toBe(OperationStatus.Success);
@@ -632,8 +713,8 @@ describe('when getting resource', () => {
             session,
             request,
             callbackContext,
-            typeConf,
-            expect.any(LoggerProxy)
+            expect.any(LoggerProxy),
+            typeConf
         );
     });
 
@@ -717,7 +798,13 @@ describe('when getting resource', () => {
     test('parse test request with object literal callback context', () => {
         const callbackContext = { a: 'b' };
         testEntrypointPayload['callbackContext'] = callbackContext;
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         const [request, action, callback] = resource['parseTestRequest'](
             testEntrypointPayload
         );
@@ -729,7 +816,13 @@ describe('when getting resource', () => {
     test('parse test request with map callback context', () => {
         const callbackContext = { a: 'b' };
         testEntrypointPayload['callbackContext'] = callbackContext;
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         const [request, action, callback] = resource['parseTestRequest'](
             testEntrypointPayload
         );
@@ -739,7 +832,13 @@ describe('when getting resource', () => {
     });
 
     test('parse test request valid request', () => {
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
         resource.addHandler(Action.Create, jest.fn());
         const [request, action, callback] = resource['parseTestRequest'](
             testEntrypointPayload
@@ -776,7 +875,7 @@ describe('when getting resource', () => {
     });
 
     test('test entrypoint missing model class', async () => {
-        const resource = new Resource(TYPE_NAME, null, null, workerPool);
+        const resource = new Resource(TYPE_NAME, null, workerPool, null);
         const event = await resource.testEntrypoint({}, null);
         expect(event).toMatchObject({
             message: 'Error: Missing Model class to be used to deserialize JSON data.',
@@ -787,7 +886,13 @@ describe('when getting resource', () => {
 
     test('test entrypoint success', async () => {
         const spyDeserialize: jest.SpyInstance = jest.spyOn(MockModel, 'deserialize');
-        const resource = new Resource(TYPE_NAME, MockModel, MockTypeConfigurationModel);
+        const resource = new Resource(
+            TYPE_NAME,
+            MockModel,
+            null,
+            null,
+            MockTypeConfigurationModel
+        );
 
         const progressEvent = ProgressEvent.progress();
         const mockHandler: jest.Mock = jest.fn(() => progressEvent);

--- a/tests/lib/resource.test.ts
+++ b/tests/lib/resource.test.ts
@@ -443,7 +443,7 @@ describe('when getting resource', () => {
         };
         expect(castResourceRequest).toThrow(exceptions.InvalidRequest);
         expect(castResourceRequest).toThrow(
-            "TypeError: Cannot read properties of null (reading 'resourceProperties')"
+            "TypeError: Cannot read property 'resourceProperties' of null (TypeError)"
         );
     });
 

--- a/tests/lib/resource.test.ts
+++ b/tests/lib/resource.test.ts
@@ -442,7 +442,9 @@ describe('when getting resource', () => {
             resource['castResourceRequest'](request);
         };
         expect(castResourceRequest).toThrow(exceptions.InvalidRequest);
-        expect(castResourceRequest).toThrow('TypeError: Cannot read property');
+        expect(castResourceRequest).toThrow(
+            "TypeError: Cannot read properties of null (reading 'resourceProperties')"
+        );
     });
 
     test('parse request valid request and cast resource request', () => {

--- a/tests/lib/resource.test.ts
+++ b/tests/lib/resource.test.ts
@@ -503,10 +503,11 @@ describe('when getting resource', () => {
         };
         expect(castResourceRequest).toThrow(exceptions.InvalidRequest);
         expect(castResourceRequest).toThrow(
-            // previously tested for (1), but now seeing (2); error message probably depends on version of JS/TS
+            // previously tested for (0) and (1), but now seeing (2); error message probably depends on version of JS/TS
+            // (0) "TypeError: Cannot read property"
             // (1) "TypeError: Cannot read property 'resourceProperties' of null (TypeError)"
             // (2) "TypeError: Cannot read properties of null (reading 'resourceProperties') (TypeError)"
-            /TypeError: Cannot read propert.*'resourceProperties'.*/
+            /TypeError: Cannot read propert(y|.*'resourceProperties'.*)/
         );
     });
 


### PR DESCRIPTION
This pull request adds type configuration support to cfn resources generated by the cli using the typescript plugin.  This matches the same functionality in the java cli plugin.