### PR TITLE
fix(cli): `cfn submit` updated to use Windows CLI when run on Windows

### DIFF
--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -236,7 +236,8 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             slash = "/"
 
         command = (
-            "npm install --optional "
+            f"cd {base_path};"
+            + "npm install --optional "
             + f"&& sam build --debug --build-dir {base_path}{slash}build"
         )
         if build_command is not None:

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -260,11 +260,9 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             if os.path.exists("/bin/bash"):
                 shell = "/bin/bash"
                 shell_arg = "-c"
-            elif os.path.exists(
-                "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
-            ):
-                shell = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
-                shell_arg = "-Command"
+            elif os.path.exists("C:/Windows/System32/cmd.exe"):
+                shell = r"C:\Windows\System32\cmd.exe"
+                shell_arg = "/C"
 
             completed_proc = subprocess_run(  # nosec
                 [shell, shell_arg, command],

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -258,7 +258,7 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             elif os.path.exists(
                 "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
             ):
-                shell = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+                shell = r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
                 shell_arg = "-Command"
 
             completed_proc = subprocess_run(  # nosec

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -230,9 +230,14 @@ class TypescriptLanguagePlugin(LanguagePlugin):
 
     @staticmethod
     def _make_build_command(base_path, build_command=None):
+        if sys.platform == "win32":
+            slash = "\\"
+        else:
+            slash = "/"
+
         command = (
             "npm install --optional "
-            + f"&& sam build --debug --build-dir {base_path}/build"
+            + f"&& sam build --debug --build-dir {base_path}{slash}build"
         )
         if build_command is not None:
             command = build_command

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -236,8 +236,7 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             slash = "/"
 
         command = (
-            f"cd {base_path};"
-            + "npm install --optional "
+            "npm install --optional "
             + f"&& sam build --debug --build-dir {base_path}{slash}build"
         )
         if build_command is not None:
@@ -261,8 +260,9 @@ class TypescriptLanguagePlugin(LanguagePlugin):
             if os.path.exists("/bin/bash"):
                 shell = "/bin/bash"
                 shell_arg = "-c"
-            elif os.path.exists("C:/Windows/System32/cmd.exe"):
-                shell = r"C:\Windows\System32\cmd.exe"
+            # On windows get command line interpreter stored in COMSPEC environment variable e.g. c:\Windows\System32\cmd.exe
+            elif os.environ.get("comspec"):
+                shell = os.environ.get("comspec")
                 shell_arg = "/C"
 
             completed_proc = subprocess_run(  # nosec

--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 import sys
 from subprocess import PIPE, CalledProcessError, run as subprocess_run  # nosec
@@ -251,13 +252,23 @@ class TypescriptLanguagePlugin(LanguagePlugin):
 
         LOG.warning("Starting build.")
         try:
+            if os.path.exists("/bin/bash"):
+                shell = "/bin/bash"
+                shell_arg = "-c"
+            elif os.path.exists(
+                "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+            ):
+                shell = "C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+                shell_arg = "-Command"
+
             completed_proc = subprocess_run(  # nosec
-                ["/bin/bash", "-c", command],
+                [shell, shell_arg, command],
                 stdout=PIPE,
                 stderr=PIPE,
                 cwd=base_path,
                 check=True,
             )
+
         except (FileNotFoundError, CalledProcessError) as e:
             raise DownstreamError("local build failed") from e
 


### PR DESCRIPTION
Closes #75
Closes https://github.com/aws-cloudformation/cloudformation-cli/issues/877

`cfn submit` was looking for `/bin/bash` explicitly when building.  Updated to look for windows CLI and updates to path when on windows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
