### PR TITLE
fix(log): Switch from console.debug to this.log in resource.ts

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -264,7 +264,7 @@ export abstract class BaseResource<
             await this.loggerProxy.waitCompletion();
         }
         await this.platformLoggerProxy.waitCompletion();
-        console.debug('Log delivery completed.');
+        this.log('Log delivery completed.');
         if (this.workerPool) {
             await this.workerPool.shutdown();
         }


### PR DESCRIPTION
Closes #65 

Switch out console.debug for this.log in src/resource.ts/waitRunningProcess()

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
