### PR TITLE
Chore(ci): use build caches for CI jobs, update npm syntax

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,7 @@
 # Continous Integration
 name: ci
 
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -26,6 +20,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.7
+          cache: 'pip'
       - name: Install Dependencies Python
         id: install_python
         run: |
@@ -36,11 +31,12 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
+          cache: 'npm'
       - name: Install Dependencies Node.js
         id: install_nodejs
         # Touch needed because of https://github.com/aws/aws-cli/issues/2639
         run: |
-          npm ci --optional
+          npm ci --include=optional
           find ./node_modules/* -mtime +10950 -exec touch {} \;
           npm run build
       - name: Run Unit Tests
@@ -74,7 +70,7 @@ jobs:
           cp "$RPDK_PATH" ./dist
           npm install "./dist/$RPDK_PACKAGE"
           cfn generate -vv && cfn validate -vv
-          npm install --optional
+          npm install --include=optional
           sam build --debug --build-dir ./build TypeFunction
           sam build --debug --build-dir ./build TestEntrypoint
           sam local invoke -t build/template.yaml --debug --event sam-tests/create.json --log-file sam.log TestEntrypoint


### PR DESCRIPTION
Closes #82 

- Set pip and npm to be cached by github actions.
- update npm ci syntax to use --include=optional
- explicitly set line endings to be LF on git checkout


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
