### PR TITLE
fix: unable to serialize array with unique items

### DIFF
--- a/src/recast.ts
+++ b/src/recast.ts
@@ -1,5 +1,5 @@
 import { InvalidRequest } from './exceptions';
-import { Callable, integer, Integer } from './interface';
+import { BaseModel, Callable, integer, Integer } from './interface';
 
 type primitive = string | number | boolean | bigint | integer | object;
 
@@ -70,7 +70,7 @@ export const transformValue = (
         });
     } else {
         // if type is plain object, we leave it as is
-        if (Object.is(cls, Object)) {
+        if (Object.is(cls, Object) || cls.prototype instanceof BaseModel) {
             return value;
         }
         if (

--- a/tests/data/sample-model.ts
+++ b/tests/data/sample-model.ts
@@ -214,14 +214,8 @@ class Tag extends BaseModel {
     ['constructor']: typeof Tag;
 
     @Expose({ name: 'Name' })
-    @Transform((value, obj) => transformValue(String, 'name', value, obj), {
-        toClassOnly: true,
-    })
     name: string;
     @Expose({ name: 'Value' })
-    @Transform((value, obj) => transformValue(String, 'value', value, obj), {
-        toClassOnly: true,
-    })
     value: string;
 }
 

--- a/tests/data/sample-model.ts
+++ b/tests/data/sample-model.ts
@@ -200,6 +200,31 @@ export class DeeperDict extends BaseModel {
     deepestList?: Optional<Array<integer>>;
 }
 
+export class TagsModel extends BaseModel {
+    ['constructor']: typeof TagsModel;
+
+    @Expose({ name: 'Tags' })
+    @Transform((value, obj) => transformValue(Tag, 'tags', value, obj, [Set]), {
+        toClassOnly: true,
+    })
+    tags?: Optional<Set<Tag>>;
+}
+
+class Tag extends BaseModel {
+    ['constructor']: typeof Tag;
+
+    @Expose({ name: 'Name' })
+    @Transform((value, obj) => transformValue(String, 'name', value, obj), {
+        toClassOnly: true,
+    })
+    name: string;
+    @Expose({ name: 'Value' })
+    @Transform((value, obj) => transformValue(String, 'value', value, obj), {
+        toClassOnly: true,
+    })
+    value: string;
+}
+
 export class SimpleResourceModel extends BaseModel {
     ['constructor']: typeof SimpleResourceModel;
 

--- a/tests/lib/recast.test.ts
+++ b/tests/lib/recast.test.ts
@@ -111,12 +111,12 @@ describe('when recasting objects', () => {
             Tags: [{ key: 'name', value: 'value' }],
         };
         const expected = {
-            tags: new Set([{ key: 'name', value: 'value' }]),
+            Tags: new Set([{ key: 'name', value: 'value' }]),
         };
         const model = TagsModel.deserialize(payload);
         const serialized = JSON.parse(JSON.stringify(model));
         expect(serialized).toMatchObject(expected);
-        // expect(TagsModel.deserialize(serialized).serialize()).toMatchObject(expected);
+        expect(TagsModel.deserialize(serialized).serialize()).toMatchObject(expected);
     });
 
     test('recast object invalid sub type', () => {

--- a/tests/lib/recast.test.ts
+++ b/tests/lib/recast.test.ts
@@ -120,14 +120,15 @@ describe('when recasting objects', () => {
     });
 
     test('recast object invalid sub type', () => {
+        class InvalidClass {}
         const k = 'key';
         const v = { a: 1, b: 2 };
         const recastObject = () => {
-            transformValue(SimpleResourceModel, k, v, {});
+            transformValue(InvalidClass, k, v, {});
         };
         expect(recastObject).toThrow(exceptions.InvalidRequest);
         expect(recastObject).toThrow(
-            `Unsupported type: ${typeof v} [${SimpleResourceModel.name}] for ${k}`
+            `Unsupported type: ${typeof v} [${InvalidClass.name}] for ${k}`
         );
     });
 

--- a/tests/lib/recast.test.ts
+++ b/tests/lib/recast.test.ts
@@ -3,6 +3,7 @@ import { transformValue, recastPrimitive } from '~/recast';
 import {
     ResourceModel as ComplexResourceModel,
     SimpleResourceModel,
+    TagsModel,
 } from '../data/sample-model';
 
 describe('when recasting objects', () => {
@@ -103,6 +104,19 @@ describe('when recasting objects', () => {
         expect(ComplexResourceModel.deserialize(serialized).serialize()).toMatchObject(
             expected
         );
+    });
+
+    test('recast set type - array with unique items', () => {
+        const payload = {
+            Tags: [{ key: 'name', value: 'value' }],
+        };
+        const expected = {
+            tags: new Set([{ key: 'name', value: 'value' }]),
+        };
+        const model = TagsModel.deserialize(payload);
+        const serialized = JSON.parse(JSON.stringify(model));
+        expect(serialized).toMatchObject(expected);
+        // expect(TagsModel.deserialize(serialized).serialize()).toMatchObject(expected);
     });
 
     test('recast object invalid sub type', () => {


### PR DESCRIPTION
*Issue #, if available:* #97

*Description of changes:*

Whenever defining an array with unique items in the resource, we will ensure those are serialized correctly instead of throwing an error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
