### PR TITLE
Update nodejs in templates to 18

### DIFF
--- a/python/rpdk/typescript/codegen.py
+++ b/python/rpdk/typescript/codegen.py
@@ -37,7 +37,7 @@ def validate_no(value):
 class TypescriptLanguagePlugin(LanguagePlugin):
     MODULE_NAME = __name__
     NAME = "typescript"
-    RUNTIME = "nodejs14.x"
+    RUNTIME = "nodejs18.x"
     ENTRY_POINT = "dist/handlers.entrypoint"
     TEST_ENTRY_POINT = "dist/handlers.testEntrypoint"
     CODE_URI = "./"


### PR DESCRIPTION
Closes #105 

Update typescript templates to use NodeJS 18.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
