### PR TITLE
update GHA runners to ubuntu latest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   delivery-nodejs:
     name: Prepare for NPM
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -35,7 +35,7 @@ jobs:
 
   delivery-python:
     name: Prepare for PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python: [3.6]
@@ -58,7 +58,7 @@ jobs:
   delivery-github:
     name: Delivery to GitHub
     needs: [delivery-nodejs, delivery-python]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Download NPM Artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Closes #107 

github runner for ubuntu 18.04 was deprecated and GHA workflows were stuck.  This updates workflows to use latest ubuntu runners.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
