### PR TITLE
Upgrading upload/download artifacts v3 to v4

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
           npm pack
       - name: Upload NPM Artifacts
         id: upload_npm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: package-npm
           path: cfn-rpdk-${{ env.VERSION }}.tgz
@@ -50,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python3 setup.py sdist bdist_wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist-py${{ matrix.python }}
           path: dist
@@ -62,11 +62,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download NPM Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: package-npm
       - name: Download Python 3.8 Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist-py3.8
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           bash codecov.sh -f coverage/ts/coverage-final.json -F unittests -n codecov-typescript
       - name: Upload Coverage Artifacts
         id: upload_coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverage/
@@ -140,7 +140,7 @@ jobs:
       - name: Upload Debug Artifacts
         id: upload_logs
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debug-logs
           path: ${{ env.LOG_PATH }}


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

PR workflows are failing due to deprecated action, upgrading deprecated action from v3 to v4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
